### PR TITLE
Closes #17 # イントロダクションページの追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -20,3 +20,8 @@
     max-width: 100%;
   }
 }
+
+.intro-image {
+  width: 200px;
+  object-fit: cover; /* 画像の縦横比を保持 */
+}

--- a/app/views/intro/_step1.html.erb
+++ b/app/views/intro/_step1.html.erb
@@ -14,7 +14,7 @@
     <!-- ステップインジケーター -->
     <div class="flex justify-center gap-2 mt-4">
       <% (1..3).each do |step| %>
-        <div class="w-3 h-3 rounded-full transition-all duration-300 <%= step == (local_assigns[:current_step] || 1) ? 'bg-amber-500' : 'bg-white bg-opacity-50' %>">
+        <div class="w-2 h-2 rounded-full transition-all duration-300 <%= step == (local_assigns[:current_step] || 1) ? 'bg-amber-500' : 'bg-white' %>">
         </div>
       <% end %>
     </div>

--- a/app/views/intro/_step2.html.erb
+++ b/app/views/intro/_step2.html.erb
@@ -1,10 +1,39 @@
-<div class="bg-neutral-200 py-12 w-screen -mx-4">
-  <div class="text-center space-y-4">
-    <img src="<%= asset_path('demo.gif') %>" alt="アプリデモ" class="mx-auto">
-    <div class="font-serif text-lg text-red-950">
+<div class="flex items-center justify-center h-full">
+  <div class="flex flex-col items-center gap-6">
+  <!-- ユーザー操作GIF（仮置き） -->
+  <div class="intro-image">
+    <%= image_tag 'Introduction.png' , class: "w-full h-full rounded-lg mt-4"%>
+  </div>
+  <!-- アプリ説明部分 -->
+  <div class="bg-neutral-200 py-6 w-screen  opacity-80">
+    <div class="font-serif text-sm space-y-1.5 text-center text-red-950">
       <p>毎日の体調をさくっと記録。</p>
       <p>顔アイコンで「調子」を選ぶだけで、</p>
       <p>簡単にゆらぎ日記がつけられます。</p>
     </div>
+    <!-- ステップインジケーター -->
+    <div class="flex justify-center gap-2 mt-4  opacity-80">
+      <% (1..3).each do |step| %>
+        <div class="w-2 h-2 rounded-full transition-all duration-300 <%= step == (local_assigns[:current_step] || 2) ? 'bg-amber-500' : 'bg-white' %>">
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- ナビゲーションボタン -->
+  <div class="flex gap-6 items-center mb-2  opacity-80">
+  <!-- 戻るボタン -->
+  <button data-action="click->intro#prevStep" class="p-3 bg-amber-600 hover:bg-amber-700 bg-opacity-90 rounded-full text-white transition-all duration-300">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+    </svg>
+  </button>
+
+  <!-- 次へボタン -->
+  <button data-action="click->intro#nextStep" class="p-3 bg-amber-600 hover:bg-amber-700 bg-opacity-90 rounded-full text-white transition-all duration-300">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+    </svg>
+  </button>
   </div>
 </div>

--- a/app/views/intro/_step3.html.erb
+++ b/app/views/intro/_step3.html.erb
@@ -1,0 +1,50 @@
+<div class="flex items-center justify-center h-full">
+  <div class="flex flex-col items-center gap-6">
+  <!-- アプリ説明部分 -->
+  <div class="bg-neutral-200 py-6 w-screen mt-10  opacity-80">
+    <div class="font-serif text-sm space-y-1.5 text-center text-red-950">
+      <p>※注意</p>
+      <br>
+      <p>本アプリはプロト版です。</p>
+      <br>
+      <p>サービス期間は</p>
+      <p>2025/9/20～2025/11/30</p>
+      <p>を予定しています。</p>
+      <br>
+      <p>サービス終了後はデータはすべて削除いたします。</p>
+      <p>（なお、画面表示はPCでもスマホサイズになります）</p>
+      <br>
+      <p>上記をご了承の上、</p>
+      <p>ご利用いただけますと幸いです。</p>
+    </div>
+    <!-- ステップインジケーター -->
+    <div class="flex justify-center gap-2 mt-4">
+      <% (1..3).each do |step| %>
+        <div class="w-2 h-2 rounded-full transition-all duration-300 <%= step == (local_assigns[:current_step] || 3) ? 'bg-amber-500' : 'bg-white' %>">
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- ナビゲーションボタン -->
+  <div class="flex gap-6 items-center mb-2  opacity-80">
+  <!-- 戻るボタン -->
+  <button data-action="click->intro#prevStep" class="p-3 bg-amber-600 hover:bg-amber-700 bg-opacity-90 rounded-full text-white transition-all duration-300">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+    </svg>
+  </button>
+
+  <!-- 次へボタン -->
+  <button data-action="click->intro#nextStep" class="p-3 rounded-full text-white transition-all duration-300">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+    </svg>
+  </button>
+  </div>
+
+  <!-- ログイン部分 -->
+  <div class="flex flex-col items-center gap-4 bg-red-900 hover:bg-amber-600 rounded-full py-7 px-10">
+    <%= link_to '手続きへ進む', '#', class: "text-sm text-center text-white font-serif" %>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
イントロダクションページの追加

## 変更内容
- introのパーシャルファイル（_step2,_step3）にイントロダクションの内容を追記

## 確認方法
1.	TOP画面にアクセス
2.	←→のボタンでパーシャルファイルの表示が非同期通信で切り替わるか
3.	それぞれのStep2、Step3のファイルで下記の表示ができているか
---
Step2
- 記録ページ・一覧ページ・グラフページの例のGIF画像設置（デモ素材仮置き）
- アプリの簡単な説明
毎日の体調をさくっと記録。
顔アイコンで「調子」を選ぶだけで、
簡単にゆらぎ日記がつけられます。
- ←→ボタンの設置
---
Step3
- アプリ利用の注意文表示
※注意

本アプリはプロト版です。

サービス期間は
2025/9/20～2025/11/30
を予定しています。

サービス終了後はデータはすべて削除いたします。
(なお、スマホアプリでの本リリースを考えているため、
画面表示はPCでもスマホサイズになります）

上記をご了承の上、
ご利用いただけますと幸いです。

- 手続きへ進む　ボタンの設置
---

## スクリーンショット
<img width="740" height="1168" alt="image" src="https://github.com/user-attachments/assets/f98da79d-66c9-404b-b93c-a502b92211b1" />
<img width="725" height="1159" alt="image" src="https://github.com/user-attachments/assets/6d6e27a0-7661-4258-960d-83cf85ceec5c" />
