### PR TITLE
Closes #16 #利用規約/健康情報の取り扱い方針の同意ページの作成

### DIFF
--- a/app/controllers/intro_controller.rb
+++ b/app/controllers/intro_controller.rb
@@ -15,4 +15,6 @@ class IntroController < ApplicationController
       head :not_found
     end
   end
+
+  def user_agreement; end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,0 @@
-class StaticPagesController < ApplicationController
-  def top; end
-end

--- a/app/javascript/controllers/agree_checkbox_controller.js
+++ b/app/javascript/controllers/agree_checkbox_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["checkbox", "submitButton"];
+  static classes = ["enabled", "disabled"];
+
+  connect() {
+    this.updateButtonState();
+  }
+
+  toggleSubmit() {
+    this.updateButtonState();
+  }
+
+  updateButtonState() {
+    const isChecked = this.checkboxTarget.checked;
+
+    if (isChecked) {
+      // チェックされた時の処理
+      this.submitButtonTarget.classList.remove(
+        "pointer-events-none",
+        "bg-gray-300",
+      );
+      this.submitButtonTarget.classList.add("bg-red-950", "hover:bg-red-800");
+    } else {
+      // チェックが外された時の処理
+      this.submitButtonTarget.classList.remove(
+        "bg-red-950",
+        "hover:bg-red-800"
+      );
+      this.submitButtonTarget.classList.add(
+        "pointer-events-none",
+        "bg-gray-300"
+      );
+    }
+  }
+
+  // オプション: スクロール位置を監視
+  trackScrollProgress(event) {
+    const element = event.currentTarget;
+    const scrollPercent =
+      (element.scrollTop / (element.scrollHeight - element.clientHeight)) * 100;
+
+    if (scrollPercent >= 95) {
+      console.log("利用規約を最後まで読みました");
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import AgreeCheckboxController from "./agree_checkbox_controller"
+application.register("agree-checkbox", AgreeCheckboxController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/intro/_step3.html.erb
+++ b/app/views/intro/_step3.html.erb
@@ -8,7 +8,7 @@
       <p>本アプリはプロト版です。</p>
       <br>
       <p>サービス期間は</p>
-      <p>2025/9/20～2025/11/30</p>
+      <p>2025/9/21～2025/11/30</p>
       <p>を予定しています。</p>
       <br>
       <p>サービス終了後はデータはすべて削除いたします。</p>
@@ -45,6 +45,6 @@
 
   <!-- ログイン部分 -->
   <div class="flex flex-col items-center gap-4 bg-red-900 hover:bg-amber-600 rounded-full py-7 px-10">
-    <%= link_to '手続きへ進む', '#', class: "text-sm text-center text-white font-serif" %>
+    <%= link_to '手続きへ進む', intro_user_agreement_path, class: "text-sm text-center text-white font-serif" %>
   </div>
 </div>

--- a/app/views/intro/user_agreement.html.erb
+++ b/app/views/intro/user_agreement.html.erb
@@ -1,0 +1,64 @@
+<div class="bg-neutral-400 relative w-full h-screen overflow-hidden" data-controller="agree-checkbox">
+  <h2 class="text-gray-700 text-sm mt-10 mb-3 ms-6">利用規約/健康情報の取り扱い方針について</h2>
+  <!-- スクロール可能な利用規約ボックス -->
+  <div class="h-80 mx-5 overflow-y-auto border border-gray-300 p-4 bg-gray-50 rounded-lg mb-6 scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-200">
+    <div class="space-y-6">
+      <div>
+        <h3 class="text-lg font-semibold mb-3 text-gray-800">1. サービスの位置づけ</h3>
+        <div class="space-y-2 text-sm text-gray-700 leading-relaxed">
+          <p>このアプリは学習目的で開発されたプロトタイプです。</p>
+          <p>公開期間は<strong class="font-semibold text-red-600">2025年9月21日〜2025年11月30日までの約3ヶ月間</strong>です。</p>
+          <p>期間終了後は、すべてのデータが削除されます。</p>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-lg font-semibold mb-3 text-gray-800">2. データの取り扱い</h3>
+        <div class="space-y-2 text-sm text-gray-700 leading-relaxed">
+          <p>登録された内容はクラウド上のデータベースに保存されます。安全性には配慮していますが、完全な保証はできかねます。</p>
+          <p>個人情報（本名・住所・電話番号など）の入力は控えてご利用ください。</p>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-lg font-semibold mb-3 text-gray-800">3. サポート・動作保証</h3>
+        <div class="space-y-2 text-sm text-gray-700 leading-relaxed">
+          <p>本アプリは学習用の試作品です。</p>
+          <p>一部動作が不安定な場合がありますが、ご了承ください。不具合や改善のご意見は、フィードバックいただけると大変助かります。</p>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-lg font-semibold mb-3 text-gray-800">4. 今後について</h3>
+        <div class="space-y-2 text-sm text-gray-700 leading-relaxed">
+          <p>本アプリは将来的にスマホアプリ化を検討しています。</p>
+          <p>プロト版の利用状況やフィードバックは、今後の改善の参考にさせていただきます。</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 同意セクション -->
+  <div class="flex flex-col items-center space-y-6">
+    <div class="flex items-center justify-center">
+      <label class="flex items-center space-x-3 cursor-pointer">
+        <input type="checkbox"
+               data-agree-checkbox-target="checkbox"
+               data-action="change->agree-checkbox#toggleSubmit"
+               class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2">
+        <span class="text-gray-700">上記の利用規約に同意します</span>
+      </label>
+    </div>
+
+    <div class="w-full max-w-xs">
+      <%= link_to '#',
+                  data: { agree_checkbox_target: "submitButton" },
+                  class: "w-full py-3 px-4 text-white rounded-lg font-medium
+                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+                          transition-colors duration-200 text-center inline-block
+                          pointer-events-none bg-gray-300" do %>
+        ユーザー登録へ進む
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
 
   get "intro", to: "intro#index"
   get "intro/step/:step", to: "intro#step"
+  get "intro/user_agreement", to: "intro#user_agreement"
 end


### PR DESCRIPTION
## 概要
利用規約/健康情報の取り扱い方針の同意ページの追加

## 変更内容
⦁	user_agreement.html.erbの作成
⦁	agree_checkboxのStimulusコントローラーの作成
⦁	ルーティングの設定
⦁	その他、サービス期間の日付等の微修正

## 確認方法
1.	TOP画面にアクセス
2.	イントロダクションの最後の「手続きへ進む」ボタンから同意ページへ遷移できるか
3.	下記の内容が表示できているか
⦁	利用規約/健康情報の取り扱い方針についてのタイトル
⦁	利用規約がスクロールバーで全文読める状態で表示
⦁	上記の利用規約に同意しますのチェックボックスが表示
⦁	チェックを入れることができるか
⦁	チェックを入れる前に、「ユーザー登録へ進む」のボタンがグレーアウトされ機能しない状態であるか
⦁	チェックを入れると、「ユーザー登録へ進む」のボタンが赤くなりルーティングが機能できる状態であるか
⦁	チェックをはずすと、「ユーザー登録へ進む」のボタンがグレーアウトされ機能しない状態に戻るか

## スクリーンショット
<img width="958" height="1378" alt="image" src="https://github.com/user-attachments/assets/363f5064-a8b3-4c17-b0a5-db7531a3f46b" />
