### PR TITLE
Related to #24 ユーザービューの作成・気象病選択のStimulus設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,10 @@ class ApplicationController < ActionController::Base
   private
 
   # 認証機能をチェックするときはコメントアウトすること
-  def check_authentication
-    return if Rails.env.development? && params[:skip_auth]
-    require_login
-  end
+  # def check_authentication
+  #   return if Rails.env.development? && params[:skip_auth]
+  #   require_login
+  # end
 
   def not_authenticated
     redirect_to login_path

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,5 +13,8 @@ application.register("hello", HelloController)
 import IntroController from "./intro_controller"
 application.register("intro", IntroController)
 
+import UserSymptomsController from "./user_symptoms_controller"
+application.register("user-symptoms", UserSymptomsController)
+
 import VideoBackgroundController from "./video_background_controller"
 application.register("video-background", VideoBackgroundController)

--- a/app/javascript/controllers/user_symptoms_controller.js
+++ b/app/javascript/controllers/user_symptoms_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="user-symptoms"
+export default class extends Controller {
+  static targets = ["button", "hiddenField"]
+  static values = { selectedSymptoms: Array }
+
+  connect() {
+    this.selectedSymptomsValue = []
+  }
+
+  toggleSymptom(event) {
+    const button = event.currentTarget
+    const symptom = button.dataset.symptom
+
+    if (this.selectedSymptomsValue.includes(symptom)) {
+      // 選択解除
+      this.selectedSymptomsValue = this.selectedSymptomsValue.filter(s => s !== symptom)
+      button.classList.remove('bg-red-950')
+      button.classList.add('bg-gray-300')
+    } else {
+      // 選択
+      this.selectedSymptomsValue = [...this.selectedSymptomsValue, symptom]
+      button.classList.remove('bg-gray-300')
+      button.classList.add('bg-red-950')
+    }
+
+    // 隠しフィールドに選択された症状を設定
+    this.hiddenFieldTarget.value = this.selectedSymptomsValue.join(',')
+  }
+}

--- a/app/views/intro/user_agreement.html.erb
+++ b/app/views/intro/user_agreement.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-neutral-400 relative w-full h-screen overflow-hidden" data-controller="agree-checkbox">
+<div class="bg-neutral-300 relative w-full h-screen overflow-hidden" data-controller="agree-checkbox">
   <h2 class="text-gray-700 text-sm mt-10 mb-3 ms-6">利用規約/健康情報の取り扱い方針について</h2>
   <!-- スクロール可能な利用規約ボックス -->
   <div class="h-80 mx-5 overflow-y-auto border border-gray-300 p-4 bg-gray-50 rounded-lg mb-6 scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-200">
@@ -56,7 +56,7 @@
                   class: "w-full py-3 px-4 text-white rounded-lg font-medium
                           focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
                           transition-colors duration-200 text-center inline-block
-                          pointer-events-none bg-gray-300" do %>
+                          pointer-events-none bg-gray-500" do %>
         ユーザー登録へ進む
       <% end %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,113 @@
-<div class="bg-neutral-400 relative w-full h-screen overflow-hidden" data-controller="agree-checkbox">
-  <h1>ユーザー登録</h1>
+<div class="bg-neutral-300 relative w-full h-screen overflow-hidden">
+  <div class="px-8">
+    <h1 class="text-gray-700 font-serif font-medium mt-8">ユーザー登録</h1>
+    <%= form_with model: @user, local: true, class: "space-y-6" do |f| %>
+
+      <!-- 気象病選択 -->
+      <div data-controller="user-symptoms">
+        <label class="block text-sm text-gray-700 font-serif mb-1">
+          お悩みの気象病を選択してください
+        </label>
+        <p class="text-xs text-gray-700 font-serif mb-1">*複数選択可</p>
+
+        <div class="grid grid-cols-2 gap-1">
+          <button type="button"
+                  data-user-symptoms-target="button"
+                  data-action="click->user-symptoms#toggleSymptom"
+                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
+                  data-symptom="mood">
+            気分
+          </button>
+          <button type="button"
+                  data-user-symptoms-target="button"
+                  data-action="click->user-symptoms#toggleSymptom"
+                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
+                  data-symptom="headache">
+            頭痛
+          </button>
+          <button type="button"
+                  data-user-symptoms-target="button"
+                  data-action="click->user-symptoms#toggleSymptom"
+                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
+                  data-symptom="sleep">
+            睡眠
+          </button>
+          <button type="button"
+                  data-user-symptoms-target="button"
+                  data-action="click->user-symptoms#toggleSymptom"
+                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
+                  data-symptom="joint_pain">
+            関節痛
+          </button>
+        </div>
+          <!-- 隠しフィールドで選択された症状を送信 -->
+          <%= f.hidden_field :user_symptoms,
+                            data: {
+                              "user-symptoms-target": "hiddenField"
+                            } %>
+      </div>
+
+
+      <!-- 郵便番号 -->
+      <div class="flex items-start gap-10">
+        <!-- ラベル部分 -->
+        <div class="flex-shrink-0 w-28">
+          <label class="block text-sm text-gray-700 font-serif mb-1">
+            郵便番号
+          </label>
+          <p class="text-xs text-gray-700 mb-0">*気象情報取得用</p>
+          <p class="text-xs text-gray-700 mt-0">*半角/ハイフンなし</p>
+        </div>
+
+        <!-- 入力フィールド部分 -->
+        <div class="flex-1">
+          <div class="flex items-center">
+            <span class="text-gray-700 mr-2">〒</span>
+            <%= f.text_field :postal_code,
+                            class: "w-32 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 text-gray-700",
+                            placeholder: "1234567",
+                            maxlength: "7" %>
+          </div>
+        </div>
+      </div>
+
+        <!-- メールアドレス -->
+      <div>
+          <label class="block text-sm text-gray-700 font-serif mb-1">
+            メールアドレス
+          </label>
+          <p class="text-xs text-gray-700 mb-2">*ログイン時に使用</p>
+
+          <%= f.email_field :email,
+                            class: "w-full max-w-sm px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 text-gray-700",
+                            placeholder: "example@email.com" %>
+      </div>
+
+      <!-- パスワード -->
+      <div class="space-y-2">
+        <div>
+          <label class="block text-sm text-gray-700 font-serif mb-1">
+            パスワード
+          </label>
+          <p class="text-xs text-gray-700 mb-2">*ログイン時に使用</p>
+
+          <%= f.password_field :password,
+                              class: "w-full max-w-sm px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 text-gray-700",
+                              placeholder: "パスワードを入力" %>
+        </div>
+
+        <div>
+          <%= f.password_field :password_confirmation,
+                              class: "w-full max-w-sm px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 text-gray-700",
+                              placeholder: "再入力" %>
+        </div>
+      </div>
+
+      <!-- 登録ボタン -->
+      <div class="text-center">
+        <%= f.submit "登録",
+                    class: "w-40 bg-gray-500 hover:bg-red-800 text-white py-3 px-4 rounded-md transition-colors duration-200 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## 概要
ユーザービューの作成・気象病選択のStimulus設定

## 変更内容
⦁	ユーザー登録のviewの作成 app/views/users/new.html.erb
⦁	気象病選択のStimulus設定を追加　app/javascript/controllers/user_symptoms_controller.js
⦁	視認性向上のため背景色の変更　bg-gray-300=>bg-gray-500

## 確認方法
⦁	http://localhost:3000/users/newにアクセス
⦁	下記要件に沿って作成されているか確認

⦁	記録したい気象病選択（気分の落ち込み/頭痛/関節痛/睡眠ー複数選択可）
⦁	郵便番号（気象情報取得用であることを明示）
⦁	メールアドレス
⦁	パスワード
⦁	登録ボタン

## 既知の問題
- モデル連携はこの後実施します

## スクリーンショット
<img width="665" height="1099" alt="image" src="https://github.com/user-attachments/assets/62085fce-ac73-4a99-8103-06819e932368" />
