### PR TITLE
ユーザー登録機能

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to diaries_path
+      redirect_to login_path, notice: '登録が完了しました'
     else
       render :new
     end
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :postalcode, :password, :password_confirmation)
+    params.require(:user).permit(:email, :password, :password_confirmation, :postal_code, user_symptoms_attributes: [:symptom_id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path, notice: '登録が完了しました'
+      redirect_to login_path
     else
       render :new
     end
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation, :postal_code, user_symptoms_attributes: [:symptom_id])
+    params.require(:user).permit(:email, :password, :password_confirmation, :postal_code, user_symptoms_attributes: [ :symptom_id ])
   end
 end

--- a/app/javascript/controllers/user_symptoms_controller.js
+++ b/app/javascript/controllers/user_symptoms_controller.js
@@ -1,31 +1,51 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="user-symptoms"
 export default class extends Controller {
-  static targets = ["button", "hiddenField"]
-  static values = { selectedSymptoms: Array }
+  static targets = ["button", "hiddenContainer"]
 
   connect() {
-    this.selectedSymptomsValue = []
+    this.selectedSymptoms = new Set()
   }
 
   toggleSymptom(event) {
     const button = event.currentTarget
-    const symptom = button.dataset.symptom
+    const symptomId = button.dataset.symptomId
+    const symptomName = button.dataset.symptomName
 
-    if (this.selectedSymptomsValue.includes(symptom)) {
+    if (this.selectedSymptoms.has(symptomId)) {
       // 選択解除
-      this.selectedSymptomsValue = this.selectedSymptomsValue.filter(s => s !== symptom)
-      button.classList.remove('bg-red-950')
-      button.classList.add('bg-gray-300')
+      this.selectedSymptoms.delete(symptomId)
+      button.classList.remove("bg-red-900")
+      button.classList.add("bg-gray-500")
+      this.removeHiddenField(symptomId)
     } else {
       // 選択
-      this.selectedSymptomsValue = [...this.selectedSymptomsValue, symptom]
-      button.classList.remove('bg-gray-300')
-      button.classList.add('bg-red-950')
+      this.selectedSymptoms.add(symptomId)
+      button.classList.remove("bg-gray-500")
+      button.classList.add("bg-red-900")
+      this.addHiddenField(symptomId)
     }
+  }
 
-    // 隠しフィールドに選択された症状を設定
-    this.hiddenFieldTarget.value = this.selectedSymptomsValue.join(',')
+  addHiddenField(symptomId) {
+    const container = this.hiddenContainerTarget
+    const index = container.children.length
+
+    // user_symptoms_attributes用の隠しフィールドを作成
+    const hiddenDiv = document.createElement('div')
+    hiddenDiv.dataset.symptomId = symptomId
+    hiddenDiv.innerHTML = `
+      <input type="hidden" name="user[user_symptoms_attributes][${index}][symptom_id]" value="${symptomId}">
+    `
+
+    container.appendChild(hiddenDiv)
+  }
+
+  removeHiddenField(symptomId) {
+    const container = this.hiddenContainerTarget
+    const targetDiv = container.querySelector(`div[data-symptom-id="${symptomId}"]`)
+    if (targetDiv) {
+      container.removeChild(targetDiv)
+    }
   }
 }

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,4 +1,8 @@
 class Diary < ApplicationRecord
   belongs_to :user
   belongs_to :weather
+  has_many :diary_symptoms, dependent: :destroy
+  has_many :symptoms, through: :diary_symptoms
+
+  accepts_nested_attributes_for :diary_symptoms, allow_destroy: true
 end

--- a/app/models/diary_symptom.rb
+++ b/app/models/diary_symptom.rb
@@ -1,4 +1,18 @@
 class DiarySymptom < ApplicationRecord
   belongs_to :diary
   belongs_to :symptom
+
+  # 症状レベルのenum
+  enum symptom_level: {
+    very_mild: 1,
+    mild: 2,
+    moderate: 3,
+    somewhat_severe: 4,
+    severe: 5,
+    very_severe: 6
+  }
+
+  # バリデーション
+  validates :symptom_level, presence: true
+  validates :oneline_diary, length: { maximum: 100, message: "は100文字以内で入力してください"  }, allow_blank: true
 end

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -1,2 +1,5 @@
 class Symptom < ApplicationRecord
+  has_many :user_symptoms, dependent: :destroy
+  has_many :users, through: :user_symptoms
+  has_many :diary_symptoms, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,18 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :email, uniqueness: true, presence: true
-  validates :postalcode, presence: true,
+  validates :postal_code, presence: true,
             format: { with: /\A\d{7}\z/, message: "は7桁の数字で入力してください" },
             length: { is: 7 }
 
-  has_many :diary, dependent: :destroy
-  has_many :symptoms, dependent: :destroy
-  has_many :symptom_diaries, through: :symptom, source: :diaries
+  has_many :user_symptoms, dependent: :destroy
+  has_many :symptoms, through: :user_symptoms
+  has_many :diaries, dependent: :destroy
+
+  accepts_nested_attributes_for :user_symptoms, allow_destroy: true, reject_if: :all_blank
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,49 +3,31 @@
     <h1 class="text-lg text-gray-700 font-serif font-medium mt-8">ユーザー登録</h1>
     <%= form_with model: @user, local: true, class: "space-y-6" do |f| %>
 
-      <!-- 気象病選択 -->
-      <div data-controller="user-symptoms">
-        <label class="block text-sm text-gray-700 font-serif mb-1">
-          お悩みの気象病を選択してください
-        </label>
-        <p class="text-xs text-gray-700 font-serif mb-1">*複数選択可</p>
+    <!-- 気象病選択セクション -->
+    <div data-controller="user-symptoms">
+      <label class="block text-sm text-gray-700 font-serif mb-1">
+        お悩みの気象病を選択してください
+      </label>
+      <p class="text-xs text-gray-700 font-serif mb-1">*複数選択可</p>
 
-        <div class="grid grid-cols-2 gap-1">
+      <div class="grid grid-cols-2 gap-1">
+        <% Symptom.all.each do |symptom| %>
           <button type="button"
                   data-user-symptoms-target="button"
                   data-action="click->user-symptoms#toggleSymptom"
                   class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
-                  data-symptom="mood">
-            気分
+                  data-symptom-id="<%= symptom.id %>"
+                  data-symptom-name="<%= symptom.name %>">
+            <%= symptom.display_name %>
           </button>
-          <button type="button"
-                  data-user-symptoms-target="button"
-                  data-action="click->user-symptoms#toggleSymptom"
-                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
-                  data-symptom="headache">
-            頭痛
-          </button>
-          <button type="button"
-                  data-user-symptoms-target="button"
-                  data-action="click->user-symptoms#toggleSymptom"
-                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
-                  data-symptom="sleep">
-            睡眠
-          </button>
-          <button type="button"
-                  data-user-symptoms-target="button"
-                  data-action="click->user-symptoms#toggleSymptom"
-                  class="text-white bg-gray-500 hover:bg-red-800 text-gray-700 py-2 px-4 rounded transition-colors duration-200"
-                  data-symptom="joint_pain">
-            関節痛
-          </button>
-        </div>
-          <!-- 隠しフィールドで選択された症状を送信 -->
-          <%= f.hidden_field :user_symptoms,
-                            data: {
-                              "user-symptoms-target": "hiddenField"
-                            } %>
+        <% end %>
       </div>
+
+      <!-- accepts_nested_attributes_for用の隠しフィールド -->
+      <div data-user-symptoms-target="hiddenContainer">
+        <!-- Stimulusで動的に生成される隠しフィールドがここに入る -->
+      </div>
+    </div>
 
 
       <!-- 郵便番号 -->

--- a/db/migrate/20250919160917_create_symptoms.rb
+++ b/db/migrate/20250919160917_create_symptoms.rb
@@ -6,31 +6,5 @@ class CreateSymptoms < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
-
-    # 初期データの投入
-    # モデルクラスへの依存を避けるためSQLで実行
-    reversible do |dir|
-      dir.up do
-        # マイグレーション実行時に初期データを作成
-        symptoms_data = [
-          { name: "mood", display_name: "気分" },
-          { name: "headache", display_name: "頭痛" },
-          { name: "sleep", display_name: "睡眠" },
-          { name: "joint_pain", display_name: "関節痛" }
-        ]
-
-        symptoms_data.each do |symptom_data|
-          execute <<-SQL
-            INSERT INTO symptoms (name, display_name, created_at, updated_at)
-            VALUES ('#{symptom_data[:name]}', '#{symptom_data[:display_name]}', NOW(), NOW())
-          SQL
-        end
-      end
-
-      dir.down do
-        # ロールバック時に作成したデータを削除
-        execute "DELETE FROM symptoms WHERE name IN ('mood', 'headache', 'sleep', 'joint_pain')"
-      end
-    end
   end
 end

--- a/db/migrate/20250919160917_create_symptoms.rb
+++ b/db/migrate/20250919160917_create_symptoms.rb
@@ -1,10 +1,36 @@
 class CreateSymptoms < ActiveRecord::Migration[7.2]
   def change
     create_table :symptoms do |t|
-      t.string :name
-      t.string :display_name
+      t.string :name, null: false
+      t.string :display_name, null: false
 
       t.timestamps
+    end
+
+    # 初期データの投入
+    # モデルクラスへの依存を避けるためSQLで実行
+    reversible do |dir|
+      dir.up do
+        # マイグレーション実行時に初期データを作成
+        symptoms_data = [
+          { name: "mood", display_name: "気分" },
+          { name: "headache", display_name: "頭痛" },
+          { name: "sleep", display_name: "睡眠" },
+          { name: "joint_pain", display_name: "関節痛" }
+        ]
+
+        symptoms_data.each do |symptom_data|
+          execute <<-SQL
+            INSERT INTO symptoms (name, display_name, created_at, updated_at)
+            VALUES ('#{symptom_data[:name]}', '#{symptom_data[:display_name]}', NOW(), NOW())
+          SQL
+        end
+      end
+
+      dir.down do
+        # ロールバック時に作成したデータを削除
+        execute "DELETE FROM symptoms WHERE name IN ('mood', 'headache', 'sleep', 'joint_pain')"
+      end
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,8 +35,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_161521) do
   end
 
   create_table "symptoms", force: :cascade do |t|
-    t.string "name"
-    t.string "display_name"
+    t.string "name", null: false
+    t.string "display_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,15 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+symptoms_data = [
+  { name: "mood", display_name: "気分" },
+  { name: "headache", display_name: "頭痛" },
+  { name: "sleep", display_name: "睡眠" },
+  { name: "joint_pain", display_name: "関節痛" }
+]
+
+symptoms_data.each do |data|
+  Symptom.find_or_create_by(name: data[:name]) do |symptom|
+    symptom.display_name = data[:display_name]
+  end
+end


### PR DESCRIPTION
## 概要
ユーザー登録機能/伴うアソシエーションの修正

## 変更内容
ユーザー登録でユーザー入力情報がUserモデルとSymptomsテーブル両方に登録されるよういろいろ変更（たくさん変更してすみません…）

## 確認方法
⦁	http://localhost:3000/users/newにアクセス
⦁	下記要件に沿って作成されているか確認

⦁	記録したい気象病選択（気分の落ち込み/頭痛/関節痛/睡眠ー複数選択可）
⦁	郵便番号（気象情報取得用であることを明示）
⦁	メールアドレス
⦁	パスワード
⦁	登録ボタン

Rails cでそれぞれのテーブルに情報が格納されているか確認

## 既知の問題
バリデーションチェックのフラッシュメッセージの設定がまだなので追加する